### PR TITLE
Add QC to mondo japanese translation repo

### DIFF
--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -2,7 +2,11 @@ name: QC for translations
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches: [ main ]
+    types: [opened, synchronize, ready_for_review]
   push:
+    branches: [ main ]
     paths:
       - 'babelon/mondo-jp.babelon.tsv'
 

--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -1,0 +1,27 @@
+name: QC for translations
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'babelon/mondo-jp.babelon.tsv'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: obolibrary/odkfull:v1.5.4
+
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+
+      - name: Run QC on translation file
+        run: |
+          BABELONFILE=babelon/mondo-jp.babelon.tsv
+          output=$(tsvalid "$BABELONFILE" --skip "W1" --skip "E1")
+          if echo "$output" | grep -Eq 'E[0-9]+:[ ]'; then
+            echo "❌ Error detected in $BABELONFILE:"
+            echo "$output"
+            exit 1
+          fi
+          babelon convert "$BABELONFILE" --output-format owl -o babelon/mondo-jp.babelon.owl


### PR DESCRIPTION
This PR will add Quality Control (QC) to the translation by checking this:

1. Whenever the translation file has changed (and only then)
2. Check if its a well formed TSV (i.e. does not have any wrong whitespace etc #4)
3. Checks if it can be converted into OWL so it can be integrated into Mondo